### PR TITLE
try restarting nginx always instead of only on errors

### DIFF
--- a/tasks/reverse_proxy.yml
+++ b/tasks/reverse_proxy.yml
@@ -7,7 +7,7 @@
   docker_container:
     name: "{{ container_names.reverse_proxy }}"
     image: "{{ image_versions.reverse_proxy }}"
-    restart_policy: unless-stopped
+    restart_policy: always
     published_ports:
       - "80:80"
       - "443:443"
@@ -29,7 +29,7 @@
   docker_container:
     name: "{{ container_names.reverse_proxy_config_generator }}"
     image: "{{ image_versions.reverse_proxy_config_generator }}"
-    restart_policy: unless-stopped
+    restart_policy: always
     command: >-
       -notify-sighup {{ container_names.reverse_proxy }} -watch -wait 5s:30s /docker-gen-templates/nginx.tmpl
       /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
- this fixes an issue with the Hub no longer being accessible due to nginx restarting before the services it depends upon are running
- this is really just a workaround and proper dependency management would be the real solution

fixes #21 