### PR TITLE
feat(oauth2): allow concurrent access tokens per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ Tracking ID of a Google Analytics Property to monitor usage of the Hub.
 
     hub_offering: "lean"
 
-Whether to display the "extended" feature set in the menu or a "lean" subset. 
+Whether to display the "extended" feature set in the menu or a "lean" subset.
+
+    concurrent_access_tokens: true
+
+Whether or not to allow one and the same user being authenticated in the same application (OAuth2 client) multiple times.
 
 #### Media Files
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ setup_wmc: true
 setup_discovery_portal: true
 setup_customization_service: true
 hub_offering: "lean"
+concurrent_access_tokens: true
 # Error Tracking configuration
 sentry_dsn:
 # Google Analytics configuration
@@ -70,6 +71,7 @@ hub_configuration:
   protocol: "{{ 'https' if letsencrypt else 'http' }}"
   create_admin_user: "{{ create_admin_user }}"
   hub_offering: "{{ hub_offering }}"
+  concurrent_access_tokens: "{{ concurrent_access_tokens }}"
 
 # Portal Configuration
 portal_hostname: "portal.{{ hub_configuration.primary_hostname }}"

--- a/tasks/main_services.yml
+++ b/tasks/main_services.yml
@@ -27,6 +27,7 @@
       RAVEN_DSN: "{{ hub_configuration.sentry_dsn | default('') }}"
       GOOGLE_ANALYTICS_TRACKING_ID: "{{ hub_configuration.google_analytics_id | default('') }}"
       HUB_OFFERING: "{{ hub_configuration.hub_offering | mandatory }}"
+      OAUTH2_ALLOW_CONCURRENT_ACCESS_TOKENS: "\"{{ hub_configuration.concurrent_access_tokens | mandatory | ternary(\"True\", \"False\") }}\""
       # yamllint enable rule:line-length
     command: supervisord -n -c /etc/supervisor/conf.d/supervisord.django.conf
     networks_cli_compatible: true
@@ -59,6 +60,7 @@
       RAVEN_DSN: "{{ hub_configuration.sentry_dsn | default('') }}"
       GOOGLE_ANALYTICS_TRACKING_ID: "{{ hub_configuration.google_analytics_id | default('') }}"
       HUB_OFFERING: "{{ hub_configuration.hub_offering | mandatory }}"
+      OAUTH2_ALLOW_CONCURRENT_ACCESS_TOKENS: "\"{{ hub_configuration.concurrent_access_tokens | mandatory | ternary(\"True\", \"False\") }}\""
       # yamllint enable rule:line-length
     command: supervisord -n -c /etc/supervisor/conf.d/supervisord.channels.conf
     networks_cli_compatible: true


### PR DESCRIPTION
We need to allow concurrent access tokens per default as otherwise cases like running the portal in the browser and within the launcher at the same time will not work. 