### PR TITLE
fix(proxy): force recreation of proxy config generator container on p…

### DIFF
--- a/tasks/reverse_proxy.yml
+++ b/tasks/reverse_proxy.yml
@@ -24,12 +24,15 @@
       - name: "{{ network_names.main }}"
         aliases:
           - nginx
+  register: reverse_proxy_result
 
 - name: Start Reverse Proxy Auto-Configuration-Service
   docker_container:
     name: "{{ container_names.reverse_proxy_config_generator }}"
     image: "{{ image_versions.reverse_proxy_config_generator }}"
     restart_policy: always
+    # recreate this container whenever the nginx container has been changed (otherwise configs won't be updated)
+    recreate: "{{ reverse_proxy_result.changed }}"
     command: >-
       -notify-sighup {{ container_names.reverse_proxy }} -watch -wait 5s:30s /docker-gen-templates/nginx.tmpl
       /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
…roxy change

if the proxy container itself changed, the proxy config generator also needs to be recreated in order to share the correct set of volumes and correctly regenerate proxy configuration. Fixes https://github.com/Innoactive/ansible-innoactive-hub-role/issues/43