### PR TITLE
feat: allow specifying sender e-mail address

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ separated list of hostnames, the Hub will then be accessible on all of these hos
 
 A user-defined, secret key used for salting hashes within the Hub's application. Never expose this to anyone!
 
+    from_email:
+
+E-Mail address from which to send transactional e-mails (e.g. onboarding) to users. If not provided, uses `admin_email`, see below.
+
     admin_email:
 
 E-Mail address of the main admin user, used to notify upon errors, expired certificates, etc.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ docker_registry:
 # Main Hub Configuration parameters
 hostname:
 secret_key:
+from_email:
 admin_email:
 admin_password:
 create_admin_user: true
@@ -60,6 +61,7 @@ hub_configuration:
   # for most following options
   primary_hostname: "{{ hostname.split(',')[0] | trim }}"
   secret_key: "{{ secret_key }}"
+  from_email: "{{ from_email }}"
   admin_email: "{{ admin_email }}"
   admin_password: "{{ admin_password }}"
   setup_database: "{{ setup_database }}"

--- a/tasks/main_services.yml
+++ b/tasks/main_services.yml
@@ -9,7 +9,7 @@
       VIRTUAL_PORT: "8000"
       DJANGO_ALLOWED_HOSTS: "{{ hub_configuration.hostname | mandatory }}"
       DJANGO_SECRET_KEY: "{{ hub_configuration.secret_key | mandatory }}"
-      FROM_EMAIL: "{{ hub_configuration.admin_email | mandatory }}"
+      FROM_EMAIL: "{{ hub_configuration.from_email | default(hub_configuration.admin_email, true) | mandatory }}"
       LETSENCRYPT_HOST: "{{ hub_configuration.hostname | mandatory }}"
       RAVEN_DSN: "{{ hub_configuration.sentry_dsn | default('') }}"
       GOOGLE_ANALYTICS_TRACKING_ID: "{{ hub_configuration.google_analytics_id | default('') }}"


### PR DESCRIPTION
- in addition to the admin's e-mail address, allow setting a dedicated sender-address
- this can e.g. be used to send e-mails from no-reply@instance