### PR TITLE
chore: recreate reverse proxy container on env / label change

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 layout_pipenv
-source .env
+dotenv

--- a/tasks/customization_service.yml
+++ b/tasks/customization_service.yml
@@ -98,6 +98,10 @@
     exposed_ports:
       - "80"
     env: "{{ default_environment_variables | combine(customization_configuration.extra_environment_variables) }}"
+    comparisons:
+      # correctly recreate container when any environment variable or labels is changed or added / removed
+      env: strict
+      labels: strict
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"

--- a/tasks/customization_service.yml
+++ b/tasks/customization_service.yml
@@ -97,7 +97,8 @@
       - "{{ volume_names.customization }}:/usr/app/media"
     exposed_ports:
       - "80"
-    env: "{{ default_environment_variables | combine(customization_configuration.extra_environment_variables) }}"
+    env: "{{ default_environment_variables | combine(customization_configuration.extra_environment_variables) | dictsort }}"
+    labels: "{{ traefik_labels | combine(alternative_domain_labels) | dictsort }}"
     comparisons:
       # correctly recreate container when any environment variable or labels is changed or added / removed
       env: strict
@@ -105,7 +106,6 @@
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"
-    labels: "{{ traefik_labels | combine(alternative_domain_labels) }}"
 
 - name: Setup Database
   become: true

--- a/tasks/customization_service.yml
+++ b/tasks/customization_service.yml
@@ -97,12 +97,12 @@
       - "{{ volume_names.customization }}:/usr/app/media"
     exposed_ports:
       - "80"
-    env: "{{ default_environment_variables | combine(customization_configuration.extra_environment_variables) | dictsort }}"
-    labels: "{{ traefik_labels | combine(alternative_domain_labels) | dictsort }}"
+    env: "{{ default_environment_variables | combine(customization_configuration.extra_environment_variables) }}"
+    labels: "{{ traefik_labels | combine(alternative_domain_labels) }}"
     comparisons:
       # correctly recreate container when any environment variable or labels is changed or added / removed
       env: strict
-      labels: strict
+      labels: allow_more_present
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"

--- a/tasks/discovery_portal.yml
+++ b/tasks/discovery_portal.yml
@@ -86,7 +86,8 @@
     restart_policy: unless-stopped
     exposed_ports:
       - "80"
-    env: "{{ default_environment_variables | combine(portal_configuration.extra_environment_variables) }}"
+    env: "{{ default_environment_variables | combine(portal_configuration.extra_environment_variables) | dictsort }}"
+    labels: "{{ traefik_labels | combine(alternative_portal_domain_labels) | dictsort }}"
     comparisons:
       # correctly recreate container when any environment variable or labels is changed or added / removed
       env: strict
@@ -94,4 +95,3 @@
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"
-    labels: "{{ traefik_labels | combine(alternative_portal_domain_labels) }}"

--- a/tasks/discovery_portal.yml
+++ b/tasks/discovery_portal.yml
@@ -86,12 +86,12 @@
     restart_policy: unless-stopped
     exposed_ports:
       - "80"
-    env: "{{ default_environment_variables | combine(portal_configuration.extra_environment_variables) | dictsort }}"
-    labels: "{{ traefik_labels | combine(alternative_portal_domain_labels) | dictsort }}"
+    env: "{{ default_environment_variables | combine(portal_configuration.extra_environment_variables) }}"
+    labels: "{{ traefik_labels | combine(alternative_portal_domain_labels) }}"
     comparisons:
       # correctly recreate container when any environment variable or labels is changed or added / removed
       env: strict
-      labels: strict
+      labels: allow_more_present
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"

--- a/tasks/discovery_portal.yml
+++ b/tasks/discovery_portal.yml
@@ -87,6 +87,10 @@
     exposed_ports:
       - "80"
     env: "{{ default_environment_variables | combine(portal_configuration.extra_environment_variables) }}"
+    comparisons:
+      # correctly recreate container when any environment variable or labels is changed or added / removed
+      env: strict
+      labels: strict
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"

--- a/tasks/main_services.yml
+++ b/tasks/main_services.yml
@@ -96,10 +96,8 @@
       - "{{ volume_names.media }}:/media"
       - "{{ volume_names.static }}:/static"
       - "{{ jwt_key_path }}:{{ jwt_key_path }}"
-    # yamllint disable rule:line-length
-    env: "{{ base_server_environment_variables | combine(admin_configuration.extra_environment_variables) }}" # noqa 204
-    # yamllint enable rule:line-length
-    labels: "{{ traefik_labels | combine(alternative_admin_domain_labels) }}"
+    env: "{{ base_server_environment_variables | combine(admin_configuration.extra_environment_variables) | dictsort }}"
+    labels: "{{ traefik_labels | combine(alternative_admin_domain_labels) | dictsort }}"
     comparisons:
       # correctly recreate container when any environment variable or labels is changed or added / removed
       env: strict

--- a/tasks/main_services.yml
+++ b/tasks/main_services.yml
@@ -100,6 +100,10 @@
     env: "{{ base_server_environment_variables | combine(admin_configuration.extra_environment_variables) }}" # noqa 204
     # yamllint enable rule:line-length
     labels: "{{ traefik_labels | combine(alternative_admin_domain_labels) }}"
+    comparisons:
+      # correctly recreate container when any environment variable or labels is changed or added / removed
+      env: strict
+      labels: strict
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"

--- a/tasks/main_services.yml
+++ b/tasks/main_services.yml
@@ -96,12 +96,12 @@
       - "{{ volume_names.media }}:/media"
       - "{{ volume_names.static }}:/static"
       - "{{ jwt_key_path }}:{{ jwt_key_path }}"
-    env: "{{ base_server_environment_variables | combine(admin_configuration.extra_environment_variables) | dictsort }}"
-    labels: "{{ traefik_labels | combine(alternative_admin_domain_labels) | dictsort }}"
+    env: "{{ base_server_environment_variables | combine(admin_configuration.extra_environment_variables) }}"
+    labels: "{{ traefik_labels | combine(alternative_admin_domain_labels) }}"
     comparisons:
       # correctly recreate container when any environment variable or labels is changed or added / removed
       env: strict
-      labels: strict
+      labels: allow_more_present
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"

--- a/tasks/reverse_proxy.yml
+++ b/tasks/reverse_proxy.yml
@@ -51,15 +51,15 @@
     image: "{{ image_versions.reverse_proxy }}"
     restart_policy: unless-stopped
     published_ports: "{{ ['80:80','443:443'] + (traefik_dashboard | ternary(['8080:8080'],[])) }}"
-    env: "{{ env_vars | combine(letsencrypt_staging_env_vars) | combine(traefik_dashboard_env_vars) | dictsort }}"
-    labels: "{{ traefik_labels | combine(letsencrypt | ternary(http_to_https_redirect_labels, {})) | dictsort }}"
+    env: "{{ env_vars | combine(letsencrypt_staging_env_vars) | combine(traefik_dashboard_env_vars) }}"
+    labels: "{{ traefik_labels | combine(letsencrypt | ternary(http_to_https_redirect_labels, {})) }}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # <== Volume for docker admin
       - "{{ volume_names.tls_certificates }}:/letsencrypt" # <== Volume for certs (TLS)
     comparisons:
       # correctly recreate container when any environment variable or labels is changed or added / removed
       env: strict
-      labels: strict
+      labels: allow_more_present
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"

--- a/tasks/reverse_proxy.yml
+++ b/tasks/reverse_proxy.yml
@@ -51,8 +51,8 @@
     image: "{{ image_versions.reverse_proxy }}"
     restart_policy: unless-stopped
     published_ports: "{{ ['80:80','443:443'] + (traefik_dashboard | ternary(['8080:8080'],[])) }}"
-    env: "{{ env_vars | combine(letsencrypt_staging_env_vars) |combine(traefik_dashboard_env_vars) }}"
-    labels: "{{ traefik_labels | combine(letsencrypt | ternary(http_to_https_redirect_labels, {})) }}"
+    env: "{{ env_vars | combine(letsencrypt_staging_env_vars) | combine(traefik_dashboard_env_vars) | dictsort }}"
+    labels: "{{ traefik_labels | combine(letsencrypt | ternary(http_to_https_redirect_labels, {})) | dictsort }}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # <== Volume for docker admin
       - "{{ volume_names.tls_certificates }}:/letsencrypt" # <== Volume for certs (TLS)

--- a/tasks/reverse_proxy.yml
+++ b/tasks/reverse_proxy.yml
@@ -56,6 +56,10 @@
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # <== Volume for docker admin
       - "{{ volume_names.tls_certificates }}:/letsencrypt" # <== Volume for certs (TLS)
+    comparisons:
+      # correctly recreate container when any environment variable or labels is changed or added / removed
+      env: strict
+      labels: strict
     networks_cli_compatible: true
     networks:
       - name: "{{ network_names.main }}"


### PR DESCRIPTION
this ensures that the relevant containers are recreated whenever an environment variable or label is added / changed / removed. By default, removed env vars / labels do not trigger a recreation