### PR TITLE
fix(traefik): wrong redirect on oauth

### DIFF
--- a/tasks/customization_service.yml
+++ b/tasks/customization_service.yml
@@ -51,7 +51,7 @@
     alternative_customization_hostnames_traefik_labels:
       # redirect alternative domains to primary
       # GET & HEAD (can be redirected)
-      traefik.http.middlewares.redirect-alternative-customization.redirectregex.regex: "(.*://)([^/]+)(.*)"
+      traefik.http.middlewares.redirect-alternative-customization.redirectregex.regex: "(.*?://)([^/]+)(.*)"
       traefik.http.middlewares.redirect-alternative-customization.redirectregex.replacement: "${1}{{ customization_configuration.hostname }}${3}"
       traefik.http.routers.customization-alternative.rule: Host({{ alias_customization_hostnames }}) && Method(`GET`,`HEAD`)
       traefik.http.routers.customization-alternative.middlewares: redirect-alternative-customization

--- a/tasks/discovery_portal.yml
+++ b/tasks/discovery_portal.yml
@@ -50,7 +50,7 @@
     alternative_portal_hostnames_traefik_labels:
       # redirect alternative domains to primary
       # GET & HEAD (can be redirected)
-      traefik.http.middlewares.redirect-alternative-portal.redirectregex.regex: "(.*://)([^/]+)(.*)"
+      traefik.http.middlewares.redirect-alternative-portal.redirectregex.regex: "(.*?://)([^/]+)(.*)"
       traefik.http.middlewares.redirect-alternative-portal.redirectregex.replacement: "${1}{{ portal_configuration.hostname }}${3}"
       traefik.http.routers.portal-alternative.rule: Host({{ traefik_portal_alternative_hostnames }}) && Method(`GET`,`HEAD`)
       traefik.http.routers.portal-alternative.middlewares: redirect-alternative-portal

--- a/tasks/main_services.yml
+++ b/tasks/main_services.yml
@@ -33,7 +33,7 @@
     alternative_admin_hostnames_traefik_labels:
       # redirect alternative domains to primary
       # GET & HEAD (can be redirected)
-      traefik.http.middlewares.redirect-alternative.redirectregex.regex: "(.*://)([^/]+)(.*)"
+      traefik.http.middlewares.redirect-alternative.redirectregex.regex: "(.*?://)([^/]+)(.*)"
       traefik.http.middlewares.redirect-alternative.redirectregex.replacement: "${1}{{ admin_configuration.hostname }}${3}"
       traefik.http.routers.web-alternative.rule: Host({{ traefik_admin_alternative_hostnames }}) && Method(`GET`,`HEAD`)
       traefik.http.routers.web-alternative.middlewares: redirect-alternative


### PR DESCRIPTION
fix for redirect


can be tested on https://regex101.com/
with this url:
https://dev.hub.innoactive.de/oauth/authorize/?client_id=iw50wRalfay3KNWET5wseIqz40vC8QR4dUvqxOK8&state=OqIW33pgf0r1Vsl_N-NPRvlEss0g9zB24zO88_1hoyo&redirect_uri=http://admin.portal.dev.innoactive.io/&response_type=code&approval_prompt=auto
 