### PR TITLE
fix(mail): use admin@<customer>.innoactive.io as default mail address

### DIFF
--- a/tasks/main_services.yml
+++ b/tasks/main_services.yml
@@ -15,7 +15,7 @@
       VIRTUAL_PORT: "8000"
       DJANGO_ALLOWED_HOSTS: "{{ ([admin_configuration.hostname] + admin_configuration.alias_hostnames) | join(',') | mandatory }}"
       DJANGO_SECRET_KEY: "{{ admin_configuration.secret_key | mandatory }}"
-      FROM_EMAIL: "{{ admin_configuration.from_email | default(admin_configuration.admin_email, true) | mandatory }}"
+      FROM_EMAIL: "{{ admin_configuration.from_email | default('admin@' + portal_configuration.hostname, true) }}"
       RAVEN_DSN: "{{ admin_configuration.sentry_dsn | default('') }}"
       GOOGLE_ANALYTICS_TRACKING_ID: "{{ admin_configuration.google_analytics_id | default('') }}"
       HUB_OFFERING: "{{ admin_configuration.hub_offering | mandatory }}"


### PR DESCRIPTION
fixed and tested. The default mail is now admin@portal.\<customer\>.\<domain\> (innoactive.io in most cases)